### PR TITLE
Update version, contributors, and repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-rules-engine",
-  "version": "6.6.0",
+  "version": "6.6.0-lineaje-01",
   "description": "Rules Engine expressed in simple json",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/cachecontrol/json-rules-engine"
+    "url": "https://github.com/lineaje-labs-gos/json-rules-engine"
   },
   "keywords": [
     "rules",
@@ -56,7 +56,11 @@
   },
   "author": "Cache Hamm <cache.hamm@gmail.com>",
   "contributors": [
-    "Chris Pardy <chris.pardy@ownup.com>"
+    "Chris Pardy <chris.pardy@ownup.com>",
+    {
+      "name": "Lineaje DepFixer",
+      "email": "221268890+Lineaje-DepFixer@users.noreply.github.com"
+    }
   ],
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
- Appended '-lineaje-01' to the version.
- Updated repository URL to point to the new repourl in lineaje-labs-gos
